### PR TITLE
Make the Labels consistent with the default port names in Openshift

### DIFF
--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -8,6 +8,8 @@
 
 FROM eclipse/centos_jdk8
 
+LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
+
 # Install nss_wrapper and gettext
 RUN sudo yum update -y && \
     sudo yum install -y cmake gettext make gcc && \


### PR DESCRIPTION
port names defined by image labels should be consistent with port names defined in  [this file](https://github.com/eclipse/che/blob/openshift-connector/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheServicePorts.java)

This fixes issue https://github.com/eclipse/che/issues/5182

Signed-off-by: David Festal <dfestal@redhat.com>