### PR TITLE
Fix build failure because /project/ folder already existed

### DIFF
--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -42,7 +42,7 @@ RUN sudo chgrp -R 0 /home/user \
   && sudo chmod -R g+rwX /etc/passwd \
   && sudo chgrp -R 0 /etc/group \
   && sudo chmod -R g+rwX /etc/group \
-  && sudo mkdir /projects \
+  && sudo mkdir -p /projects \
   && sudo chgrp -R 0 /projects \
   && sudo chmod -R g+rwX /projects
   

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -42,7 +42,7 @@ RUN sudo chgrp -R 0 /home/user \
   && sudo chmod -R g+rwX /etc/passwd \
   && sudo chgrp -R 0 /etc/group \
   && sudo chmod -R g+rwX /etc/group \
-  && sudo mkdir /projects \
+  && sudo mkdir -p /projects \
   && sudo chgrp -R 0 /projects \
   && sudo chmod -R g+rwX /projects
   


### PR DESCRIPTION
Jenkins job is failing: https://ci.centos.org/view/Devtools/job/devtools-che-dockerfiles-build-che-credentials-master/6/

This commit should fix the build failure