### PR TITLE
initialize maven dependencies for springboot and vertx

### DIFF
--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -69,10 +69,8 @@ ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
 
 COPY ["init-maven.sh","/tmp/init-maven.sh"]
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/spring-boot/spring-boot-configmap-booster.yaml /tmp/booster1.yaml
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/spring-boot/spring-boot-health-check-booster.yaml /tmp/booster2.yaml
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/spring-boot/spring-boot-rest-http-booster.yaml /tmp/booster3.yaml
-RUN sudo chown user:user /tmp/init-maven.sh /tmp/booster*.yaml && \
+ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/heads/osio /tmp/current-osio-sha1
+RUN sudo chown user:user /tmp/init-maven.sh && \
     chmod +x /tmp/init-maven.sh && \
     /tmp/init-maven.sh && \
-    sudo rm -f /tmp/init-maven.sh
+    sudo rm -f /tmp/init-maven.sh /tmp/current-osio-sha1

--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -67,3 +67,12 @@ COPY ["entrypoint.sh","/home/user/entrypoint.sh"]
 
 ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
+
+COPY ["init-maven.sh","/tmp/init-maven.sh"]
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/spring-boot/spring-boot-configmap-booster.yaml /tmp/booster1.yaml
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/spring-boot/spring-boot-health-check-booster.yaml /tmp/booster2.yaml
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/spring-boot/spring-boot-rest-http-booster.yaml /tmp/booster3.yaml
+RUN sudo chown user:user /tmp/init-maven.sh /tmp/booster*.yaml && \
+    chmod +x /tmp/init-maven.sh && \
+    /tmp/init-maven.sh && \
+    sudo rm -f /tmp/init-maven.sh

--- a/recipes/spring-boot/init-maven.sh
+++ b/recipes/spring-boot/init-maven.sh
@@ -19,7 +19,7 @@ get_repository() {
 }
 
 git_clone_and_build() {
-  CONTENT=$(cat "${1}")
+  CONTENT=$(curl -s "${1}")
   BRANCH=$(get_branch "${CONTENT}")
   REPOSITORY=$(get_repository "${CONTENT}")
   cd "${HOME}"
@@ -29,10 +29,9 @@ git_clone_and_build() {
 
   git clone -b "${BRANCH}" "${REPOSITORY}" tmp-folder
   cd tmp-folder && scl enable rh-maven33 'mvn clean package'
-  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder & rm "${1}"
+  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder
 }
 
-# iterate on all boosters
-for filename in /tmp/booster*.yaml; do
-  git_clone_and_build "${filename}"
-done
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/spring-boot/spring-boot-configmap-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/spring-boot/spring-boot-health-check-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/spring-boot/spring-boot-rest-http-booster.yaml

--- a/recipes/spring-boot/init-maven.sh
+++ b/recipes/spring-boot/init-maven.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) 2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+#
+
+set -e
+set -u
+
+get_branch() {
+  echo "${1}" | grep "gitRef" | awk -F : '{print $2}' | xargs
+}
+
+get_repository() {
+  echo "https://github.com/$(echo "${1}" | grep "githubRepo" | awk -F : '{print $2}' | xargs)"
+}
+
+git_clone_and_build() {
+  CONTENT=$(cat "${1}")
+  BRANCH=$(get_branch "${CONTENT}")
+  REPOSITORY=$(get_repository "${CONTENT}")
+  cd "${HOME}"
+  CURRENT_FOLDER=$(pwd)
+
+  echo "cloning with git clone -b ${BRANCH} ${REPOSITORY} tmp-folder"
+
+  git clone -b "${BRANCH}" "${REPOSITORY}" tmp-folder
+  cd tmp-folder && scl enable rh-maven33 'mvn clean package'
+  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder & rm "${1}"
+}
+
+# iterate on all boosters
+for filename in /tmp/booster*.yaml; do
+  git_clone_and_build "${filename}"
+done

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -69,10 +69,9 @@ ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
 
 COPY ["init-maven.sh","/tmp/init-maven.sh"]
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/vert.x/vertx-http-booster.yaml /tmp/booster1.yaml
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/vert.x/vertx-configmap-booster.yaml /tmp/booster2.yaml
-ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/vert.x/vertx-health-check-booster.yaml /tmp/booster3.yaml
-RUN sudo chown user:user /tmp/init-maven.sh /tmp/booster*.yaml && \
+ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/heads/osio /tmp/current-osio-sha1
+RUN sudo chown user:user /tmp/init-maven.sh && \
     chmod +x /tmp/init-maven.sh && \
     /tmp/init-maven.sh && \
-    sudo rm -f /tmp/init-maven.sh
+    sudo rm -f /tmp/init-maven.sh /tmp/current-osio-sha1
+

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -64,6 +64,15 @@ ENV HOME /home/user
 
 # Overwride entrypoint
 COPY ["entrypoint.sh","/home/user/entrypoint.sh"]
-
 ENTRYPOINT ["/home/user/entrypoint.sh"]
+
 CMD tail -f /dev/null
+
+COPY ["init-maven.sh","/tmp/init-maven.sh"]
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/vert.x/vertx-http-booster.yaml /tmp/booster1.yaml
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/vert.x/vertx-configmap-booster.yaml /tmp/booster2.yaml
+ADD https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/vert.x/vertx-health-check-booster.yaml /tmp/booster3.yaml
+RUN sudo chown user:user /tmp/init-maven.sh /tmp/booster*.yaml && \
+    chmod +x /tmp/init-maven.sh && \
+    /tmp/init-maven.sh && \
+    sudo rm -f /tmp/init-maven.sh

--- a/recipes/vertx/init-maven.sh
+++ b/recipes/vertx/init-maven.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) 2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+#
+
+set -e
+set -u
+
+get_branch() {
+  echo "${1}" | grep "gitRef" | awk -F : '{print $2}' | xargs
+}
+
+get_repository() {
+  echo "https://github.com/$(echo "${1}" | grep "githubRepo" | awk -F : '{print $2}' | xargs)"
+}
+
+git_clone_and_build() {
+  CONTENT=$(cat "${1}")
+  BRANCH=$(get_branch "${CONTENT}")
+  REPOSITORY=$(get_repository "${CONTENT}")
+  cd "${HOME}"
+  CURRENT_FOLDER=$(pwd)
+
+  echo "cloning with git clone -b ${BRANCH} ${REPOSITORY} tmp-folder"
+
+  git clone -b "${BRANCH}" "${REPOSITORY}" tmp-folder
+  cd tmp-folder && scl enable rh-maven33 'mvn clean package'
+  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder & rm "${1}"
+}
+
+# iterate on all boosters
+for filename in /tmp/booster*.yaml; do
+  git_clone_and_build "${filename}"
+done

--- a/recipes/vertx/init-maven.sh
+++ b/recipes/vertx/init-maven.sh
@@ -19,7 +19,7 @@ get_repository() {
 }
 
 git_clone_and_build() {
-  CONTENT=$(cat "${1}")
+  CONTENT=$(curl -s "${1}")
   BRANCH=$(get_branch "${CONTENT}")
   REPOSITORY=$(get_repository "${CONTENT}")
   cd "${HOME}"
@@ -29,10 +29,10 @@ git_clone_and_build() {
 
   git clone -b "${BRANCH}" "${REPOSITORY}" tmp-folder
   cd tmp-folder && scl enable rh-maven33 'mvn clean package'
-  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder & rm "${1}"
+  cd "${CURRENT_FOLDER}" && rm -rf tmp-folder
 }
 
-# iterate on all boosters
-for filename in /tmp/booster*.yaml; do
-  git_clone_and_build "${filename}"
-done
+
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/vert.x/vertx-http-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/vert.x/vertx-configmap-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/vert.x/vertx-health-check-booster.yaml


### PR DESCRIPTION
### What the PR is doing ?
For springboot and vertx, compile the quickstart examples in order to populate the .m2 repository

note: if quickstart catalog is updated, it will then pickup the new version of the quickstart

###  how it is working ?
- we add in Dockerfile the path to catalog YAML into a /tmp/booster<numer>.yaml file
- the `init-maven.sh` script extract data from all `booster*.yaml`files and then clone the repository, and use maven to build the examples. Once it is build, it removes the cloned project

Linked to issue https://github.com/openshiftio/openshift.io/issues/496