### PR TITLE
Osio branch was removed

### DIFF
--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -57,7 +57,7 @@ ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
 
 COPY ["init-maven.sh","/tmp/init-maven.sh"]
-ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/heads/osio /tmp/current-osio-sha1
+ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/tags/v10 /tmp/current-osio-sha1
 RUN sudo chown user:user /tmp/init-maven.sh && \
     chmod +x /tmp/init-maven.sh && \
     /tmp/init-maven.sh && \
@@ -73,4 +73,6 @@ RUN sudo chgrp -R 0 /home/user \
   && sudo chmod -R g+rwX /etc/group \
   && sudo mkdir -p /projects \
   && sudo chgrp -R 0 /projects \
-  && sudo chmod -R g+rwX /projects
+  && sudo chmod -R g+rwX /projects \
+  && sudo chgrp -R 0 /tmp \
+  && sudo chmod -R g+rwX /tmp

--- a/recipes/spring-boot/init-maven.sh
+++ b/recipes/spring-boot/init-maven.sh
@@ -32,6 +32,6 @@ git_clone_and_build() {
   cd "${CURRENT_FOLDER}" && rm -rf tmp-folder
 }
 
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/spring-boot/spring-boot-configmap-booster.yaml
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/spring-boot/spring-boot-health-check-booster.yaml
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/spring-boot/spring-boot-rest-http-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/configmap/spring-boot/spring-boot-configmap-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/health-check/spring-boot/spring-boot-health-check-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/rest-http/spring-boot/spring-boot-rest-http-booster.yaml

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -57,7 +57,7 @@ ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
 
 COPY ["init-maven.sh","/tmp/init-maven.sh"]
-ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/heads/osio /tmp/current-osio-sha1
+ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/tags/v10 /tmp/current-osio-sha1
 RUN sudo chown user:user /tmp/init-maven.sh && \
     chmod +x /tmp/init-maven.sh && \
     /tmp/init-maven.sh && \

--- a/recipes/vertx/init-maven.sh
+++ b/recipes/vertx/init-maven.sh
@@ -33,6 +33,6 @@ git_clone_and_build() {
 }
 
 
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/rest-http/vert.x/vertx-http-booster.yaml
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/configmap/vert.x/vertx-configmap-booster.yaml
-git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/osio/health-check/vert.x/vertx-health-check-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/rest-http/vert.x/vertx-http-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/configmap/vert.x/vertx-configmap-booster.yaml
+git_clone_and_build https://raw.githubusercontent.com/openshiftio/booster-catalog/v10/health-check/vert.x/vertx-health-check-booster.yaml


### PR DESCRIPTION
osio branch has been removed: https://github.com/openshiftio/booster-catalog/issues/108

use v10 tag instead
also update permissions on /tmp

you can test spring-boot image with `florentbenoit/springboot-20171003`docker image