### PR TITLE
Set _JAVA_OPTIONS in workspace images.

### DIFF
--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -50,6 +50,11 @@ RUN cat /etc/group | \
 
 ENV HOME /home/user
 
+# Set _JAVA_OPTIONS environment variable so as to make spawned
+# java processes respect the container limit and use reasonable
+# GC configuration for small JVMs.
+ENV _JAVA_OPTIONS "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+
 # Overwride entrypoint
 COPY ["entrypoint.sh","/home/user/entrypoint.sh"]
 

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -50,6 +50,11 @@ RUN cat /etc/group | \
 
 ENV HOME /home/user
 
+# Set _JAVA_OPTIONS environment variable so as to make spawned
+# java processes respect the container limit and use reasonable
+# GC configuration for small JVMs.
+ENV _JAVA_OPTIONS "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+
 # Overwride entrypoint
 COPY ["entrypoint.sh","/home/user/entrypoint.sh"]
 ENTRYPOINT ["/home/user/entrypoint.sh"]

--- a/recipes/wildfly-swarm/Dockerfile
+++ b/recipes/wildfly-swarm/Dockerfile
@@ -62,6 +62,11 @@ RUN cat /etc/group | \
 
 ENV HOME /home/user
 
+# Set _JAVA_OPTIONS environment variable so as to make spawned
+# java processes respect the container limit and use reasonable
+# GC configuration for small JVMs.
+ENV _JAVA_OPTIONS "-XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m"
+
 # Overwride entrypoint
 COPY ["entrypoint.sh","/home/user/entrypoint.sh"]
 


### PR DESCRIPTION
This will allow for spawned JVM processes within a Che workspace to
pick up the container memory limit. Options:

    -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap

Additionally, ParallelGC with tunings for small JVMs will be used
which helps keeping the VmRSS of spawned processes down. Options:

    -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20
    -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms20m

Finally, disable memory mapping of jar files which reduces VmRSS some
more. Options:

    -Dsun.zip.disableMemoryMapping=true