### PR TITLE
Install 32 bit OpenJDK over 64 bit.

### DIFF
--- a/recipes/spring-boot/Dockerfile
+++ b/recipes/spring-boot/Dockerfile
@@ -24,6 +24,12 @@ RUN sudo yum update -y && \
     sudo yum clean all && \
     sudo rm -rf /tmp/* /var/cache/yum
 
+# Install 32 bit OpenJDK. Remove 64 bit OpenJDK
+RUN sudo yum -y install java-1.8.0-openjdk-devel.i686 && \
+    sudo yum -y remove java-1.8.0-openjdk-headless.x86_64 && \
+    sudo yum clean all && \
+    java -version
+
 # Install nodejs for ls agents and OpenShift CLI
 RUN sudo yum update -y && \
     curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash - && \

--- a/recipes/vertx/Dockerfile
+++ b/recipes/vertx/Dockerfile
@@ -24,6 +24,12 @@ RUN sudo yum update -y && \
     sudo yum clean all && \
     sudo rm -rf /tmp/* /var/cache/yum
 
+# Install 32 bit OpenJDK. Remove 64 bit OpenJDK
+RUN sudo yum -y install java-1.8.0-openjdk-devel.i686 && \
+    sudo yum -y remove java-1.8.0-openjdk-headless.x86_64 && \
+    sudo yum clean all && \
+    java -version
+
 # Install nodejs for ls agents and OpenShift CLI
 RUN sudo yum update -y && \
     curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash - && \


### PR DESCRIPTION
For the vert.x and spring-boot stacks. This allows for significant memory footprint savings
without sacrificing functionality.