### PR TITLE
Updating vert.x configmap quickstart to the latest version `v14`

### DIFF
--- a/recipes/vertx/init-maven.sh
+++ b/recipes/vertx/init-maven.sh
@@ -26,5 +26,5 @@ git_clone_and_build() {
 
 
 git_clone_and_build https://github.com/openshiftio-vertx-boosters/vertx-http-booster-redhat v12
-git_clone_and_build https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster-redhat v13
+git_clone_and_build https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster-redhat v14
 git_clone_and_build https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster-redhat v12


### PR DESCRIPTION
related faric8-launcher PR https://github.com/fabric8-launcher/launcher-booster-catalog/pull/230