### PR TITLE
Add /tmp to list of folders whose group and permissions are changed

### DIFF
--- a/recipes/context/grant-access-arbitrary-UID.sh
+++ b/recipes/context/grant-access-arbitrary-UID.sh
@@ -7,8 +7,8 @@
 # Contributors:
 # Red Hat, Inc. - initial implementation
 #
-# Change owner and group of /home/user, /etc/passwd, /etc/group/ and
-# /projects directories, to allow users with arbitrary UIDs.
+# Change owner and group of /home/user, /etc/passwd, /etc/group/
+# /projects and /tmp directories, to allow users with arbitrary UIDs.
 #####
 
 set -u
@@ -22,6 +22,6 @@ sudo chgrp -R 0 /home/user \
   && sudo chmod -R g+rwX /etc/group \
   && sudo mkdir -p /projects \
   && sudo chgrp -R 0 /projects \
-  && sudo chmod -R g+rwX /projects
-  # && sudo chgrp -R 0 /tmp \
-  # && sudo chmod -R g+rwX /tmp
+  && sudo chmod -R g+rwX /projects \
+  && sudo chgrp -R 0 /tmp \
+  && sudo chmod -R g+rwX /tmp


### PR DESCRIPTION
Fixes issue where some images require access to files stored in `/tmp`. When these files are created during build, they have incorrect permissions, causing builds within workspaces to fail.

The spring-boot image was definitely affected by this. Prior to https://github.com/redhat-developer/che-dockerfiles/pull/37, the wildfly-swarm image also had the `chgrp /tmp` command. This PR adds the command to all images for simplicity.