### PR TITLE
rh-che #780: Wildfly runtime has been renamed to the 'thorntail'

### DIFF
--- a/recipes/dockerfiles/wildfly-swarm/Dockerfile
+++ b/recipes/dockerfiles/wildfly-swarm/Dockerfile
@@ -59,8 +59,8 @@ COPY ["./context/download-maven-deps.sh", \
 ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/tags/v10 /tmp/current-osio-sha1
 RUN sudo chown user:user /tmp/maven-deps /tmp/maven-deps/* && \
     /tmp/maven-deps/maven-deps.install \
-        'wildfly-swarm' \
-        # 'configmap' \
+        'thorntail' \
+        # 'configmap' \ @see https://github.com/redhat-developer/rh-che/issues/734
         'health-check' \
         'rest-http' && \
     sudo rm -rf /tmp/maven-deps


### PR DESCRIPTION
request to https://forge.api.openshift.io/api/booster-catalog with `X-App:osio` return thorntail instead of wildfly:

> "mission": "health-check",
> "name": "Thorntail - Health Checks",
> "description": "Demonstrates Health Checks in Thorntail",
> "runtime": "thorntail",