### PR TITLE
Minor fixes for build issues in centos-nodejs and thorntail images

### DIFF
--- a/recipes/context/nss_wrapper_nodejs.install
+++ b/recipes/context/nss_wrapper_nodejs.install
@@ -22,6 +22,8 @@ set -e
 sudo yum update -y \
   && sudo yum install -y \
     cmake \
+    gcc \
+    make \
   && cd /home/user/ \
   && git clone git://git.samba.org/nss_wrapper.git \
   && cd nss_wrapper \
@@ -31,5 +33,7 @@ sudo yum update -y \
   && cd /home/user && rm -rf ./nss_wrapper \
   && sudo yum remove -y \
     cmake \
+    gcc \
+    make \
   && sudo yum clean all \
   && sudo rm -rf /tmp/* /var/cache/yum

--- a/recipes/dockerfiles/wildfly-swarm/Dockerfile
+++ b/recipes/dockerfiles/wildfly-swarm/Dockerfile
@@ -10,8 +10,6 @@ FROM registry.centos.org/che-stacks/wildfly-swarm
 
 ARG OC_VERSION=3.9.38
 
-RUN sudo yum list installed
-
 # Install general dependencies
 COPY ["./context/general-deps.install", "/tmp/install/"]
 RUN sudo chown user:user /tmp/install /tmp/install/* && \
@@ -52,18 +50,20 @@ COPY ["./context/entrypoint.sh","/home/user/entrypoint.sh"]
 ENTRYPOINT ["/home/user/entrypoint.sh"]
 CMD tail -f /dev/null
 
+# Thorntail boosters are disabled in catalog
+#
 # Download maven dependencies
-COPY ["./context/download-maven-deps.sh", \
-      "./context/maven-deps.install", \
-      "/tmp/maven-deps/"]
-ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/tags/v10 /tmp/current-osio-sha1
-RUN sudo chown user:user /tmp/maven-deps /tmp/maven-deps/* && \
-    /tmp/maven-deps/maven-deps.install \
-        'thorntail' \
-        # 'configmap' \ @see https://github.com/redhat-developer/rh-che/issues/734
-        'health-check' \
-        'rest-http' && \
-    sudo rm -rf /tmp/maven-deps
+# COPY ["./context/download-maven-deps.sh", \
+#       "./context/maven-deps.install", \
+#       "/tmp/maven-deps/"]
+# ADD https://api.github.com/repos/openshiftio/booster-catalog/git/refs/tags/v10 /tmp/current-osio-sha1
+# RUN sudo chown user:user /tmp/maven-deps /tmp/maven-deps/* && \
+#     /tmp/maven-deps/maven-deps.install \
+#         'thorntail' \
+#         # 'configmap' \ @see https://github.com/redhat-developer/rh-che/issues/734
+#         'health-check' \
+#         'rest-http' && \
+#     sudo rm -rf /tmp/maven-deps
 
 # Give write access to /home/user for users with an arbitrary UID
 COPY ["./context/grant-access-arbitrary-UID.sh", "/tmp/install/"]


### PR DESCRIPTION
### Changes
- At some point, the upstream image for centos-nodejs was changed to not  include gcc / make, breaking the nss_wrapper install step
- There are no currently enabled thorntail boosters in the osio catalog, so they have to be temporarily disabled. See https://github.com/redhat-developer/rh-che/issues/1149 for tracking.

rhche issue: https://github.com/redhat-developer/rh-che/issues/1104