### PR TITLE
Fix CI build timeout issue

### DIFF
--- a/cico_build_publish_images.sh
+++ b/cico_build_publish_images.sh
@@ -24,7 +24,7 @@ for d in recipes/dockerfiles/*/ ; do
   image=$(basename $d)
 
   echo "Building $image"
-  docker build -t ${image} -f ${d}/Dockerfile ./recipes | cat
+  docker build -t ${image} -f ${d}/Dockerfile ./recipes
   if [ $? -ne 0 ]; then
     echo 'ERROR: Docker build failed'
     exit_with_error="yes"

--- a/recipes/context/download-maven-deps.sh
+++ b/recipes/context/download-maven-deps.sh
@@ -40,7 +40,7 @@ git_clone_and_build() {
   echo "cloning with git clone -b ${BRANCH} ${REPOSITORY} tmp-folder"
 
   git clone -b "${BRANCH}" "${REPOSITORY}" tmp-folder
-  cd tmp-folder && scl enable rh-maven33 'mvn clean package'
+  cd tmp-folder && scl enable rh-maven33 'mvn -B clean package'
   cd "${CURRENT_FOLDER}" && rm -rf tmp-folder
 }
 

--- a/recipes/context/general-deps.install
+++ b/recipes/context/general-deps.install
@@ -22,15 +22,15 @@ set -e
 OC_VERSION=${1}
 JAVA_VERSION=${2:-1.8.0}
 
-sudo yum update -y | cat \
-  && sudo yum install -y \
+sudo yum update -y -d 1 \
+  && sudo yum install -y -d 1 \
     bzip2 \
     curl \
     gettext \
     git \
     java-${JAVA_VERSION}-openjdk-devel \
     tar \
-    wget | cat \
+    wget \
   && sudo wget -qO- "https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz" \
     | sudo tar xvz -C /usr/local/bin \
   && sudo yum clean all \

--- a/recipes/context/maven-deps.install
+++ b/recipes/context/maven-deps.install
@@ -16,9 +16,9 @@ set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 
-sudo yum --enablerepo=extras install epel-release -y | cat && \
-  sudo yum update -y | cat && \
-  sudo yum install -y jq | cat && \
+sudo yum --enablerepo=extras install epel-release -y && \
+  sudo yum update -y -d 1 && \
+  sudo yum install -y -d 1 jq && \
   /${SCRIPT_DIR}/download-maven-deps.sh $@ && \
   sudo yum remove jq -y && \
   sudo yum remove epel-release -y && \

--- a/recipes/context/nodejs.install
+++ b/recipes/context/nodejs.install
@@ -13,9 +13,9 @@
 set -u
 set -e
 
-sudo yum update -y \
+sudo yum update -y -d 1 \
   && curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash - \
-  && sudo yum install -y \
-    nodejs | cat\
+  && sudo yum install -y -d 1 \
+    nodejs \
   && sudo yum clean all \
   && sudo rm -rf /tmp/* /var/cache/yum

--- a/recipes/context/nss_wrapper.install
+++ b/recipes/context/nss_wrapper.install
@@ -14,11 +14,11 @@
 set -u
 set -e
 
-sudo yum update -y \
-  && sudo yum install -y \
+sudo yum update -y -d 1 \
+  && sudo yum install -y -d 1 \
     cmake \
     gcc \
-    make | cat \
+    make \
   && cd /home/user/ \
   && git clone git://git.samba.org/nss_wrapper.git \
   && cd nss_wrapper \

--- a/recipes/context/nss_wrapper_nodejs.install
+++ b/recipes/context/nss_wrapper_nodejs.install
@@ -19,11 +19,11 @@
 set -u
 set -e
 
-sudo yum update -y | cat \
-  && sudo yum install -y \
+sudo yum update -y -d 1 \
+  && sudo yum install -y -d 1 \
     cmake \
     gcc \
-    make | cat \
+    make \
   && cd /home/user/ \
   && git clone git://git.samba.org/nss_wrapper.git \
   && cd nss_wrapper \

--- a/recipes/dockerfiles/centos_dotnet20/Dockerfile
+++ b/recipes/dockerfiles/centos_dotnet20/Dockerfile
@@ -16,8 +16,10 @@ ENV OMNISHARP_DOWNLOAD_URL="https://github.com/OmniSharp/omnisharp-roslyn/releas
 ENV CSHARP_LS_DIR=${HOME}/che/ls-csharp
 
 # Install OpenShift CLI
-RUN sudo yum update -y | cat && \
-    sudo yum install -y tar wget | cat && \
+RUN sudo yum update -y -d 1 && \
+    sudo yum install -y -d 1 \
+      tar \
+      wget && \
     sudo wget -qO- "https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz" | sudo tar xvz -C /usr/local/bin && \
     sudo yum clean all && \
     sudo rm -rf /tmp/* /var/cache/yum

--- a/recipes/dockerfiles/centos_nodejs_community/Dockerfile
+++ b/recipes/dockerfiles/centos_nodejs_community/Dockerfile
@@ -5,9 +5,12 @@ LABEL che:server:8003:ref=angular che:server:8003:protocol=http che:server:3000:
 
 # Install general dependencies
 RUN curl -sL https://rpm.nodesource.com/setup_11.x | sudo bash -
-RUN sudo yum update -y | cat && \
-    sudo yum downgrade -y audit-libs audit | cat && \
-    sudo yum install -y bzip2 rh-git29-git | cat && \
-    sudo yum install -y nodejs | cat && \
+RUN sudo yum update -y -d 1 && \
+    sudo yum downgrade -y audit-libs audit && \
+    sudo yum install -y -d 1 \
+      bzip2 \
+      rh-git29-git && \
+    sudo yum install -y -d 1 \
+      nodejs && \
     sudo yum clean all -y && \
     sudo rm -rf /var/cache/yum

--- a/recipes/dockerfiles/centos_php/Dockerfile
+++ b/recipes/dockerfiles/centos_php/Dockerfile
@@ -10,10 +10,10 @@ FROM registry.centos.org/che-stacks/centos-stack-base:latest
 ENV PHP_LS_VERSION=5.4.1 \
     OC_VERSION=3.9.38
 USER root
-RUN yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm \
+RUN yum install -y -d 1 epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm  \
     yum-utils && \
     yum-config-manager --enable remi-php71 && \
-    yum install -y \
+    yum install -y -d 1 \
         rpmdevtools \
         php \
         php-bcmath \
@@ -39,7 +39,7 @@ RUN yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release
         php-pecl-imagick \
         php-pecl-redis \
         unzip \
-        httpd | cat && \
+        httpd && \
         yum --enablerepo=epel install -y fcgi && \
         yum clean all && \
         sed -i 's/\/var\/www\/html/\/projects/g'  /etc/httpd/conf/httpd.conf && \

--- a/recipes/dockerfiles/centos_python/Dockerfile
+++ b/recipes/dockerfiles/centos_python/Dockerfile
@@ -14,8 +14,9 @@ ENV PATH=/opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}} \
     XDG_DATA_DIRS="/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
     OC_VERSION=3.9.38
 USER root
-RUN yum update -y | cat && \
-    yum install rh-python36 -y | cat && \
+RUN yum update -y -d 1 && \
+    yum install -y -d 1 \
+      rh-python36 && \
     yum clean all
 
 RUN pip install --upgrade pip && \

--- a/recipes/dockerfiles/centos_ruby/Dockerfile
+++ b/recipes/dockerfiles/centos_ruby/Dockerfile
@@ -22,21 +22,28 @@ ENV PATH=/home/user/bin:/opt/rh/rh-ruby25/root/usr/local/bin:/opt/rh/rh-ruby25/r
 
 USER root
 
-RUN yum install -y centos-release-scl-rh | cat && \
+RUN yum install -y -d 1 \
+        centos-release-scl-rh && \
     yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-ruby25-rh-candidate/x86_64/os/ && \
     echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-ruby25-rh-candidate_x86_64_os_.repo && \
-    INSTALL_PKGS=" \
-                  ${RUBY_SCL} \
-                  ${RUBY_SCL}-ruby-devel \
-                  ${RUBY_SCL}-rubygem-rake \
-                  ${RUBY_SCL}-rubygem-bundler \
-                  " && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} gcc g++ make zlib-devel sqlite-devel openssl openssl-devel | cat && \
+    yum install -y -d 1 --setopt=tsflags=nodocs \
+        ${RUBY_SCL} \
+        ${RUBY_SCL}-ruby-devel \
+        ${RUBY_SCL}-rubygem-rake \
+        ${RUBY_SCL}-rubygem-bundler \
+        gcc \
+        g++ \
+        make \
+        zlib-devel \
+        sqlite-devel \
+        openssl \
+        openssl-devel && \
     rpm -V ${INSTALL_PKGS} && \
     gem install rails sqlite3 && \
     sudo chmod -R 777 /opt/rh/rh-ruby25 && \
-    sudo curl --silent --location https://rpm.nodesource.com/setup_8.x | sudo bash - && \
-    sudo yum install -y nodejs | cat && \
+    sudo curl -sS --location https://rpm.nodesource.com/setup_8.x | sudo bash - && \
+    sudo yum install -y -d 1 \
+        nodejs && \
     yum clean all -y && \
     sudo wget -qO- "https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz" | sudo tar xvz -C /usr/local/bin
 USER user


### PR DESCRIPTION
Looks like piping a docker build through cat naively is a bad idea ;)

- Don't pipe docker build through cat because it's really slow (maven build especially)
- Run maven in noninteractive mode to suppress progress meters
- Use `yum -d 1 [...]` instead of `yum [...] | cat`