### PR TITLE
install nss_wrapper package instead of building it from its master source (fixes #50)

### DIFF
--- a/recipes/context/nss_wrapper.install
+++ b/recipes/context/nss_wrapper.install
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2012-2019 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,20 +15,8 @@ set -u
 set -e
 
 sudo yum update -y -d 1 \
+  && sudo yum install -y epel-release \
   && sudo yum install -y -d 1 \
-    cmake \
-    gcc \
-    make \
-  && cd /home/user/ \
-  && git clone git://git.samba.org/nss_wrapper.git \
-  && cd nss_wrapper \
-  && mkdir obj && cd obj \
-  && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DLIB_SUFFIX=64 .. \
-  && make && sudo make install \
-  && cd /home/user && rm -rf ./nss_wrapper \
-  && sudo yum remove -y \
-    cmake \
-    gcc \
-    make \
+    nss_wrapper \
   && sudo yum clean all \
   && sudo rm -rf /tmp/* /var/cache/yum


### PR DESCRIPTION
This requires using EPEL (core CentOS does not provide nss_wrapper).

An alternative solution to the broken build problem is to keep building nss_wrapper from its (master!) source as it is now, but use cmake3 instead of cmake 2.x.

Full background story and analysis is documented in #50.