### PR TITLE
use cmake3 in nss_wrapper.install (fixes #50)

### DIFF
--- a/recipes/context/nss_wrapper.install
+++ b/recipes/context/nss_wrapper.install
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2012-2019 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -15,19 +15,20 @@ set -u
 set -e
 
 sudo yum update -y -d 1 \
+  && sudo yum install -y epel-release \
   && sudo yum install -y -d 1 \
-    cmake \
+    cmake3 \
     gcc \
     make \
   && cd /home/user/ \
   && git clone git://git.samba.org/nss_wrapper.git \
   && cd nss_wrapper \
   && mkdir obj && cd obj \
-  && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DLIB_SUFFIX=64 .. \
+  && cmake3 -DCMAKE_INSTALL_PREFIX=/usr/local -DLIB_SUFFIX=64 .. \
   && make && sudo make install \
   && cd /home/user && rm -rf ./nss_wrapper \
   && sudo yum remove -y \
-    cmake \
+    cmake3 \
     gcc \
     make \
   && sudo yum clean all \


### PR DESCRIPTION
This requires using EPEL (core CentOS only has cmake 2.x).

An alternative solution is proposed in #52 which would be to to not build nss_wrapper from its (master!) source, but instead to install it from a package; but that also requires EPEL, and would likely lead to an older (but stable..) version of nss_wrapper than build from source.

Full background story and analysis is documented in #50.