### PR TITLE
 initial version of Quarkus.io image

### DIFF
--- a/recipes/dockerfiles/centos_quarkus.io_jdk8/Dockerfile
+++ b/recipes/dockerfiles/centos_quarkus.io_jdk8/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# Contributors:
+# Red Hat, Inc. - initial implementation
+
+FROM registry.centos.org/che-stacks/centos-quarkus.io-jdk8
+
+ARG OC_VERSION=3.9.38
+
+# Install general dependencies
+COPY ["./context/general-deps.install", "/tmp/install/"]
+RUN sudo chown user:user /tmp/install /tmp/install/* && \
+    /tmp/install/general-deps.install ${OC_VERSION} && \
+    sudo rm -rf /tmp/install
+
+# Install nss_wrapper
+COPY ["./context/nss_wrapper.install", "/tmp/install/"]
+RUN sudo chown user:user /tmp/install /tmp/install/* && \
+    /tmp/install/nss_wrapper.install && \
+    sudo rm -rf /tmp/install
+
+# Install nodejs
+COPY ["./context/nodejs.install", "/tmp/install/"]
+RUN sudo chown user:user /tmp/install /tmp/install/* && \
+    /tmp/install/nodejs.install && \
+    sudo rm -rf /tmp/install
+
+# The following lines are needed to set the correct locale after `yum update`
+# c.f. https://github.com/CentOS/sig-cloud-instance-images/issues/71
+RUN sudo localedef -i en_US -f UTF-8 C.UTF-8
+ENV LANG="C.UTF-8"
+
+# Generate passwd.template
+RUN cat /etc/passwd | \
+    sed s#user:x.*#user:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g \
+    > /home/user/passwd.template
+
+# Generate group.template
+RUN cat /etc/group | \
+    sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g \
+    > /home/user/group.template
+
+ENV HOME /home/user
+
+# Overwride entrypoint
+COPY ["./context/entrypoint.sh", "/home/user/entrypoint.sh"]
+ENTRYPOINT ["/home/user/entrypoint.sh"]
+CMD tail -f /dev/null
+
+# Give write access to /home/user for users with an arbitrary UID
+COPY ["./context/grant-access-arbitrary-UID.sh", "/tmp/install/"]
+RUN sudo chown user:user /tmp/install /tmp/install/* && \
+    /tmp/install/grant-access-arbitrary-UID.sh && \
+    sudo rm -rf /tmp/install


### PR DESCRIPTION
see tqvarnst/quarkus-workshop#2

and https://github.com/eclipse/che-dockerfiles/pull/240

This just follows the pattern of the other containers like the `centos_jdk8` and `spring-boot` and `vertx` here.

We don't have to download maven dependencies because https://github.com/eclipse/che-dockerfiles/pull/240 already does that.

The idea of why this is needed on top of https://github.com/eclipse/che-dockerfiles/pull/240 is because IMHO it's useful to have the `oc` client available, and this seems to do a number of other tricks which must be here for good reasons (all of which probably shouldn't be part of https://github.com/eclipse/che-dockerfiles/pull/240 - again just following the existing pattern).

This PR builds on top of #52. If #52 is abandoned in favour of #53 then this can be rebased.